### PR TITLE
Fix parser eats non-whitespace

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <version>6</version>
   </parent>
   <artifactId>kojan-xml</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.0.1-SNAPSHOT</version>
   <name>Kojan XML</name>
   <description>A simple library for modeling and writing data in XML format</description>
   <url>https://github.com/mizdebsk/kojan-xml</url>

--- a/src/test/java/io/kojan/xml/BasicTest.java
+++ b/src/test/java/io/kojan/xml/BasicTest.java
@@ -133,7 +133,7 @@ class BasicTest {
     @Test
     void testTextInWrongPlace() throws Exception {
         xml = "<car>text</car>";
-        expectException = "Expected white space";
+        expectException = "Expected </car> end element";
         performTest();
     }
 

--- a/src/test/java/io/kojan/xml/XMLParserTest.java
+++ b/src/test/java/io/kojan/xml/XMLParserTest.java
@@ -1,0 +1,77 @@
+/*-
+ * Copyright (c) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.kojan.xml;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.StringReader;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Mikolaj Izdebski
+ */
+class XMLParserTest {
+    @Test
+    void testParse() throws Exception {
+        String xml =
+                """
+                <root>
+                  <foo> abc</foo>
+                  <bar/>
+                </root>
+                """;
+        StringReader r = new StringReader(xml);
+        XMLParserImpl p = new XMLParserImpl(r);
+
+        assertFalse(p.hasStartElement());
+        assertTrue(p.parseText().isBlank());
+        p.parseStartDocument();
+
+        assertTrue(p.hasStartElement());
+        assertTrue(p.hasStartElement("root"));
+        assertTrue(p.parseText().isBlank());
+        assertEquals("root", p.parseStartElement());
+
+        assertTrue(p.hasStartElement());
+        assertTrue(p.hasStartElement("foo"));
+        assertTrue(p.parseText().isBlank());
+        assertEquals("foo", p.parseStartElement());
+
+        assertFalse(p.hasStartElement());
+        assertEquals(" abc", p.parseText());
+
+        assertFalse(p.hasStartElement());
+        assertTrue(p.parseText().isEmpty());
+        p.parseEndElement("foo");
+
+        assertTrue(p.hasStartElement());
+        assertTrue(p.hasStartElement("bar"));
+        assertTrue(p.parseText().isBlank());
+        assertEquals("bar", p.parseStartElement());
+
+        assertFalse(p.hasStartElement());
+        assertTrue(p.parseText().isEmpty());
+        p.parseEndElement("bar");
+
+        assertFalse(p.hasStartElement());
+        assertTrue(p.parseText().isBlank());
+        p.parseEndElement("root");
+
+        assertFalse(p.hasStartElement());
+        assertTrue(p.parseText().isBlank());
+        p.parseEndDocument();
+    }
+}


### PR DESCRIPTION
Fix an issue with XMLParser eagerly eating non-whitespace text.

For example, when cursor is at:

    foo<bar>...

Then calling `XMLParser.hasStartElement()` correctly returns `false`, but as unintended side effect it eats the `foo` text, leaving parser at this position:

    <bar>...